### PR TITLE
Add filterbuyer command and relevant predicates

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterBuyersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterBuyersCommand.java
@@ -1,10 +1,9 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CHARACTERISTICS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CHARACTERISTICS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/commands/FilterBuyersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterBuyersCommand.java
@@ -10,8 +10,9 @@ import seedu.address.model.Model;
 import seedu.address.model.person.AbstractFilterBuyerPredicate;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Filters and lists all buyers in the buyer list that either have a price range that accepts the given price,
+ * characteristics that match the given characteristics list, or have the given tag.
+ * Keyword matching is case-insensitive.
  */
 public class FilterBuyersCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/FilterBuyersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterBuyersCommand.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CHARACTERISTICS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.AbstractFilterBuyerPredicate;
+
+/**
+ * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FilterBuyersCommand extends Command {
+
+    public static final String COMMAND_WORD = "filterbuyers";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all buyers in the database who"
+            + " either have a price range that accepts the given price, characteristics that match the given"
+            + " characteristics list, or has the given tag.\n"
+            + "Parameters: [" + PREFIX_PRICE + " PRICE] "
+            + "[" + PREFIX_CHARACTERISTICS + " CHARACTERISTICS]"
+            // TODO change this from tag to priority after andre's refactor
+            + "[" + PREFIX_TAG + " <HIGH/LOW>]\n"
+            + "Example: " + COMMAND_WORD + " -c bright; sunny";
+
+    private final AbstractFilterBuyerPredicate predicate;
+
+    public FilterBuyersCommand(AbstractFilterBuyerPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FilterBuyersCommand // instanceof handles nulls
+                && predicate.equals(((FilterBuyersCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,7 +6,20 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddPersonCommand;
+import seedu.address.logic.commands.AddPropertyCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteBuyerCommand;
+import seedu.address.logic.commands.DeletePropertyCommand;
+import seedu.address.logic.commands.EditBuyerCommand;
+import seedu.address.logic.commands.EditPropertyCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterBuyersCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListBuyersCommand;
+import seedu.address.logic.commands.ListPropertiesCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,19 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddPersonCommand;
-import seedu.address.logic.commands.AddPropertyCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteBuyerCommand;
-import seedu.address.logic.commands.DeletePropertyCommand;
-import seedu.address.logic.commands.EditBuyerCommand;
-import seedu.address.logic.commands.EditPropertyCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListBuyersCommand;
-import seedu.address.logic.commands.ListPropertiesCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -83,6 +71,9 @@ public class AddressBookParser {
 
         case EditPropertyCommand.COMMAND_WORD:
             return new EditPropertyCommandParser().parse(arguments);
+
+        case FilterBuyersCommand.COMMAND_WORD:
+            return new FilterBuyersCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/FilterBuyersCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterBuyersCommandParser.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CHARACTERISTICS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.commands.FilterBuyersCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.FilterBuyerByCharacteristicsPredicate;
+import seedu.address.model.person.FilterBuyerByPricePredicate;
+
+import static java.util.Objects.requireNonNull;
+
+public class FilterBuyersCommandParser extends Parser<FilterBuyersCommand> {
+
+    public FilterBuyersCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CHARACTERISTICS, PREFIX_PRICE,
+                PREFIX_TAG);
+
+        if (argMultimap.getValue(PREFIX_PRICE).isPresent()) {
+            try {
+                return new FilterBuyersCommand(new FilterBuyerByPricePredicate(argMultimap.getValue(PREFIX_PRICE).get()));
+            } catch (Exception e) {
+                throw new ParseException(e.getMessage());
+            }
+        }
+        // BUG: Owing to StringUtil.containsWordIgnoreCase, characteristics can only be a single word.
+        // However, the error message does not show up in the dialog box in the GUI. 
+        if (argMultimap.getValue(PREFIX_CHARACTERISTICS).isPresent()) {
+            try {
+            return new FilterBuyersCommand(new FilterBuyerByCharacteristicsPredicate(argMultimap
+                    .getValue(PREFIX_CHARACTERISTICS).get()));
+            } catch (Exception e) {
+                throw new ParseException(e.getMessage());
+            }
+        }
+        // TODO andre: add case for tags
+
+        throw new ParseException(FilterBuyersCommand.MESSAGE_USAGE);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/FilterBuyersCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterBuyersCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CHARACTERISTICS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -9,10 +10,18 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.FilterBuyerByCharacteristicsPredicate;
 import seedu.address.model.person.FilterBuyerByPricePredicate;
 
-import static java.util.Objects.requireNonNull;
 
+
+/**
+ * Parses user input to create a {@code FilterBuyersCommand}.
+ */
 public class FilterBuyersCommandParser extends Parser<FilterBuyersCommand> {
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterBuyersCommand
+     * and returns an FilterBuyersCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public FilterBuyersCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
@@ -21,16 +30,17 @@ public class FilterBuyersCommandParser extends Parser<FilterBuyersCommand> {
 
         if (argMultimap.getValue(PREFIX_PRICE).isPresent()) {
             try {
-                return new FilterBuyersCommand(new FilterBuyerByPricePredicate(argMultimap.getValue(PREFIX_PRICE).get()));
+                return new FilterBuyersCommand(new FilterBuyerByPricePredicate(argMultimap
+                        .getValue(PREFIX_PRICE).get()));
             } catch (Exception e) {
                 throw new ParseException(e.getMessage());
             }
         }
         // BUG: Owing to StringUtil.containsWordIgnoreCase, characteristics can only be a single word.
-        // However, the error message does not show up in the dialog box in the GUI. 
+        // However, the error message does not show up in the dialog box in the GUI.
         if (argMultimap.getValue(PREFIX_CHARACTERISTICS).isPresent()) {
             try {
-            return new FilterBuyersCommand(new FilterBuyerByCharacteristicsPredicate(argMultimap
+                return new FilterBuyersCommand(new FilterBuyerByCharacteristicsPredicate(argMultimap
                     .getValue(PREFIX_CHARACTERISTICS).get()));
             } catch (Exception e) {
                 throw new ParseException(e.getMessage());

--- a/src/main/java/seedu/address/model/desiredcharacteristics/DesiredCharacteristics.java
+++ b/src/main/java/seedu/address/model/desiredcharacteristics/DesiredCharacteristics.java
@@ -1,11 +1,11 @@
 package seedu.address.model.desiredcharacteristics;
 
-import seedu.address.commons.util.StringUtil;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.Arrays;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Represents the desired characteristics of a property that will interest a particular buyer.

--- a/src/main/java/seedu/address/model/desiredcharacteristics/DesiredCharacteristics.java
+++ b/src/main/java/seedu/address/model/desiredcharacteristics/DesiredCharacteristics.java
@@ -1,5 +1,7 @@
 package seedu.address.model.desiredcharacteristics;
 
+import seedu.address.commons.util.StringUtil;
+
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
@@ -43,6 +45,16 @@ public class DesiredCharacteristics {
     public static boolean isValidDesiredCharacteristics(String test) {
         return test.matches(VALIDATION_REGEX);
     }
+
+    /**
+     * Helper method which returns true if a given characteristic is contained in the desired
+     * characteristics.
+     */
+    public boolean containsCharacteristic(String characteristic) {
+        return Arrays.stream(characteristics)
+                .anyMatch(c -> StringUtil.containsWordIgnoreCase(c, characteristic));
+    }
+
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/person/AbstractFilterBuyerPredicate.java
+++ b/src/main/java/seedu/address/model/person/AbstractFilterBuyerPredicate.java
@@ -1,0 +1,15 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+/**
+ * An abstract class for predicates within the FilterBuyers method.
+ * Since there are three possible ways that a {@code filterbuyers} command can be executed,
+ * we need to create an abstract class that can be passed into the {@code FilterBuyersCommand} constructor,
+ * after which each individual predicate's behaviour is determined through polymorphism.
+ */
+public abstract class AbstractFilterBuyerPredicate implements Predicate<Person> {
+
+    @Override
+    public abstract boolean test(Person person);
+}

--- a/src/main/java/seedu/address/model/person/AbstractFilterBuyerPredicate.java
+++ b/src/main/java/seedu/address/model/person/AbstractFilterBuyerPredicate.java
@@ -4,7 +4,7 @@ import java.util.function.Predicate;
 
 /**
  * An abstract class for predicates within the FilterBuyers method.
- * Since there are three possible ways that a {@code filterbuyers} command can be executed,
+ * Since there are three possible ways that a {@code FilterBuyersCommand}  can be executed,
  * we need to create an abstract class that can be passed into the {@code FilterBuyersCommand} constructor,
  * after which each individual predicate's behaviour is determined through polymorphism.
  */

--- a/src/main/java/seedu/address/model/person/FilterBuyerByCharacteristicsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FilterBuyerByCharacteristicsPredicate.java
@@ -1,0 +1,35 @@
+package seedu.address.model.person;
+
+import seedu.address.model.desiredcharacteristics.DesiredCharacteristics;
+
+import java.util.Arrays;
+
+/**
+ * Tests that a given {@code Person}'s {@code DesiredCharacteristics} contains the given characteristic.
+ */
+public class FilterBuyerByCharacteristicsPredicate extends AbstractFilterBuyerPredicate{
+
+    private static final String CHARACTERISTIC_DELIMITER = ";";
+
+    private final String[] givenCharacteristics;
+
+    public FilterBuyerByCharacteristicsPredicate(String characteristics) {
+        this.givenCharacteristics = characteristics.split(CHARACTERISTIC_DELIMITER);
+    }
+
+    @Override
+    public boolean test(Person p) {
+        // N.B.: Returns true if the target person does not have a DesiredCharacteristics object in their attributes.
+        if (p.getDesiredCharacteristics().isEmpty()) return true;
+        DesiredCharacteristics dc =  p.getDesiredCharacteristics().get();
+        return Arrays.stream(givenCharacteristics).anyMatch(dc::containsCharacteristic);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FilterBuyerByCharacteristicsPredicate // instanceof handles nulls
+                && Arrays.equals(givenCharacteristics,
+                    ((FilterBuyerByCharacteristicsPredicate) other).givenCharacteristics)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/person/FilterBuyerByCharacteristicsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FilterBuyerByCharacteristicsPredicate.java
@@ -15,6 +15,10 @@ public class FilterBuyerByCharacteristicsPredicate extends AbstractFilterBuyerPr
 
     private final String[] givenCharacteristics;
 
+    /**
+     * Standard constructor for the predicate. characteristics must be delimited
+     * by semicolons.
+     */
     public FilterBuyerByCharacteristicsPredicate(String characteristics) {
         requireNonNull(characteristics);
         this.givenCharacteristics = characteristics.split(CHARACTERISTIC_DELIMITER);

--- a/src/main/java/seedu/address/model/person/FilterBuyerByCharacteristicsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FilterBuyerByCharacteristicsPredicate.java
@@ -1,13 +1,13 @@
 package seedu.address.model.person;
 
-import seedu.address.model.desiredcharacteristics.DesiredCharacteristics;
-
 import java.util.Arrays;
+
+import seedu.address.model.desiredcharacteristics.DesiredCharacteristics;
 
 /**
  * Tests that a given {@code Person}'s {@code DesiredCharacteristics} contains the given characteristic.
  */
-public class FilterBuyerByCharacteristicsPredicate extends AbstractFilterBuyerPredicate{
+public class FilterBuyerByCharacteristicsPredicate extends AbstractFilterBuyerPredicate {
 
     private static final String CHARACTERISTIC_DELIMITER = ";";
 
@@ -20,8 +20,10 @@ public class FilterBuyerByCharacteristicsPredicate extends AbstractFilterBuyerPr
     @Override
     public boolean test(Person p) {
         // N.B.: Returns true if the target person does not have a DesiredCharacteristics object in their attributes.
-        if (p.getDesiredCharacteristics().isEmpty()) return true;
-        DesiredCharacteristics dc =  p.getDesiredCharacteristics().get();
+        if (p.getDesiredCharacteristics().isEmpty()) {
+            return true;
+        }
+        DesiredCharacteristics dc = p.getDesiredCharacteristics().get();
         return Arrays.stream(givenCharacteristics).anyMatch(dc::containsCharacteristic);
     }
 
@@ -29,7 +31,7 @@ public class FilterBuyerByCharacteristicsPredicate extends AbstractFilterBuyerPr
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FilterBuyerByCharacteristicsPredicate // instanceof handles nulls
-                && Arrays.equals(givenCharacteristics,
-                    ((FilterBuyerByCharacteristicsPredicate) other).givenCharacteristics)); // state check
+                && Arrays.equals(givenCharacteristics, (
+                        (FilterBuyerByCharacteristicsPredicate) other).givenCharacteristics)); // state check
     }
 }

--- a/src/main/java/seedu/address/model/person/FilterBuyerByCharacteristicsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FilterBuyerByCharacteristicsPredicate.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Arrays;
 
 import seedu.address.model.desiredcharacteristics.DesiredCharacteristics;
@@ -14,6 +16,7 @@ public class FilterBuyerByCharacteristicsPredicate extends AbstractFilterBuyerPr
     private final String[] givenCharacteristics;
 
     public FilterBuyerByCharacteristicsPredicate(String characteristics) {
+        requireNonNull(characteristics);
         this.givenCharacteristics = characteristics.split(CHARACTERISTIC_DELIMITER);
     }
 

--- a/src/main/java/seedu/address/model/person/FilterBuyerByPricePredicate.java
+++ b/src/main/java/seedu/address/model/person/FilterBuyerByPricePredicate.java
@@ -16,7 +16,9 @@ public class FilterBuyerByPricePredicate extends AbstractFilterBuyerPredicate {
     @Override
     public boolean test(Person p) {
         // N.B.: Returns true if the target person does not have a PriceRange object in their attributes.
-        if (p.getPriceRange().isEmpty()) return true;
+        if (p.getPriceRange().isEmpty()) {
+            return true;
+        }
         return p.getPriceRange().get().isWithinPriceRange(price);
     }
 

--- a/src/main/java/seedu/address/model/person/FilterBuyerByPricePredicate.java
+++ b/src/main/java/seedu/address/model/person/FilterBuyerByPricePredicate.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.model.property.Price;
 
 /**
@@ -10,6 +12,7 @@ public class FilterBuyerByPricePredicate extends AbstractFilterBuyerPredicate {
     private final Price price;
 
     public FilterBuyerByPricePredicate(String stringPrice) {
+        requireNonNull(stringPrice);
         this.price = new Price(stringPrice);
     }
 

--- a/src/main/java/seedu/address/model/person/FilterBuyerByPricePredicate.java
+++ b/src/main/java/seedu/address/model/person/FilterBuyerByPricePredicate.java
@@ -1,0 +1,30 @@
+package seedu.address.model.person;
+
+import seedu.address.model.property.Price;
+
+/**
+ * Tests that a {@code Person}'s {@code PriceRange} contains the given price value.
+ */
+public class FilterBuyerByPricePredicate extends AbstractFilterBuyerPredicate {
+
+    private final Price price;
+
+    public FilterBuyerByPricePredicate(String stringPrice) {
+        this.price = new Price(stringPrice);
+    }
+
+    @Override
+    public boolean test(Person p) {
+        // N.B.: Returns true if the target person does not have a PriceRange object in their attributes.
+        if (p.getPriceRange().isEmpty()) return true;
+        return p.getPriceRange().get().isWithinPriceRange(price);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FilterBuyerByPricePredicate // instanceof handles nulls
+                && price.equals(((FilterBuyerByPricePredicate) other).price)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/FilterBuyerByPricePredicate.java
+++ b/src/main/java/seedu/address/model/person/FilterBuyerByPricePredicate.java
@@ -11,6 +11,10 @@ public class FilterBuyerByPricePredicate extends AbstractFilterBuyerPredicate {
 
     private final Price price;
 
+    /**
+     * Standard constructor for the predicate. stringPrice will be validated
+     * by Price's constructor.
+     */
     public FilterBuyerByPricePredicate(String stringPrice) {
         requireNonNull(stringPrice);
         this.price = new Price(stringPrice);

--- a/src/main/java/seedu/address/model/pricerange/PriceRange.java
+++ b/src/main/java/seedu/address/model/pricerange/PriceRange.java
@@ -5,6 +5,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.text.DecimalFormat;
 
+import seedu.address.model.property.Price;
+
 /**
  * Represents a Price Range for a property that a buyer can accept.
  * Guarantees: immutable; is valid as declared.
@@ -20,8 +22,8 @@ public class PriceRange {
      */
     public static final String VALIDATION_REGEX = "[0-9]*\\.?[0-9]+\\s?-\\s?[0-9]*\\.?[0-9]+";
 
-    public final double low;
-    public final double high;
+    public final Price low;
+    public final Price high;
 
     /**
      * Constructs a {@code PriceRange}.
@@ -32,8 +34,8 @@ public class PriceRange {
         checkArgument(isValidPriceRange(priceRange), MESSAGE_CONSTRAINTS);
 
         String[] rangeValues = priceRange.split("-");
-        this.low = Double.parseDouble(rangeValues[0].trim());
-        this.high = Double.parseDouble(rangeValues[1].trim());
+        this.low = new Price(rangeValues[0].trim());
+        this.high = new Price(rangeValues[1].trim());
     }
 
     /**
@@ -56,8 +58,7 @@ public class PriceRange {
         double rightValue = Double.parseDouble(rangeValues[1].trim());
         boolean isRightValueValid = rightValue >= 0 && rightValue < Double.POSITIVE_INFINITY;
 
-        return isValid
-                && isLeftValueValid
+        return isLeftValueValid
                 && isRightValueValid
                 && (leftValue - rightValue <= 0);
     }
@@ -65,8 +66,8 @@ public class PriceRange {
     /*
     Checks if a given float value is within the price range.
      */
-    public boolean isWithinPriceRange(float f) {
-        return (f - low >= 0 && high - f >= 0);
+    public boolean isWithinPriceRange(Price p) {
+        return (low.isSmallerThan(p) && high.isGreaterThan(p));
     }
 
     @Override
@@ -76,9 +77,9 @@ public class PriceRange {
         // and causing parsing bugs when being converted back into a float
         DecimalFormat df = new DecimalFormat("#");
         df.setMaximumFractionDigits(0);
-        sb.append(df.format(low));
+        sb.append(df.format(low.getNumericalValue()));
         sb.append(" - ");
-        sb.append(df.format(high));
+        sb.append(df.format(high.getNumericalValue()));
         return sb.toString();
     }
 

--- a/src/main/java/seedu/address/model/property/Price.java
+++ b/src/main/java/seedu/address/model/property/Price.java
@@ -11,9 +11,11 @@ public class Price {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Price should only contain numbers, and it should not be blank.";
-    public static final String VALIDATION_REGEX = "\\d+";
+            "Price should only contain numbers and an optional exponent. For example: 123.45";
+    public static final String VALIDATION_REGEX = "^[0-9]*\\.*[0-9]+$";
+    public static final double EPSILON = 0.01d;
     public final String value;
+    public final double numericalValue;
 
     /**
      * Constructs a {@code Price}.
@@ -24,6 +26,7 @@ public class Price {
         requireNonNull(price);
         checkArgument(isValidPrice(price), MESSAGE_CONSTRAINTS);
         value = price;
+        numericalValue = Double.parseDouble(price);
     }
 
     /**
@@ -31,6 +34,28 @@ public class Price {
      */
     public static boolean isValidPrice(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    // TODO testing for these methods
+
+    /**
+     * Returns true if the stored numerical value is greater than a given {@code Price}.
+     */
+    public boolean isGreaterThan(Price p) {
+        double d = p.getNumericalValue();
+        return numericalValue - d > EPSILON || numericalValue - d == 0;
+    }
+
+    /**
+     * Returns true if the stored numerical value is smaller than a given {@code Price}.
+     */
+    public boolean isSmallerThan(Price p) {
+        double d = p.getNumericalValue();
+        return d - numericalValue > EPSILON || numericalValue - d == 0;
+    }
+
+    public double getNumericalValue() {
+        return this.numericalValue;
     }
 
     @Override


### PR DESCRIPTION
## New Features

`filterbuyers` command now works for `-price` and `-c`. Prices must take the form defined in the `Price` class.

## Bugs
Characteristics that are passed into -c must be singular words because of `StringUtil.containsWordIgnoreCase`. We might want to fix this in the future, but discussion is required before making changes.

For some reason, the error message that is thrown by `StringUtil` does not get passed up to `FilterBuyersCommandParser` and hence is not displayed in the error box to the user.

## TODOs
Test cases have not yet been implemented.
