### PR TITLE
Require whitespace after flag when tokenizing args

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -70,7 +70,7 @@ public class ArgumentTokenizer {
      * {@code fromIndex} = 0, this method returns 5.
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
+        int prefixIndex = argsString.indexOf(" " + prefix + " ", fromIndex);
         return prefixIndex == -1 ? -1
                 : prefixIndex + 1; // +1 as offset for whitespace
     }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -71,8 +71,12 @@ public class ArgumentTokenizer {
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
         int prefixIndex = argsString.indexOf(" " + prefix + " ", fromIndex);
-        return prefixIndex == -1 ? -1
-                : prefixIndex + 1; // +1 as offset for whitespace
+        int endingPrefixIndex = argsString.indexOf(" " + prefix, fromIndex);
+        return prefixIndex != -1
+                ? prefixIndex + 1 // +1 as offset for whitespace
+                : endingPrefixIndex != -1
+                ? endingPrefixIndex + 1 // +1 as offset for whitespace
+                : -1;
     }
 
     /**


### PR DESCRIPTION
Hotfix for the errors in parsing caused by #215.

in AB3, the flag was in the format "<flag>/", thus the ArgumentTokenizer only checked for a whitespace before the flag to recognise it as that flag. this implementation was not changed when we changed the flag format to "-<flag>". this continues to work, as long as we do not have flags that had the same prefix (e.g. "-p" and "-ph"), in which case both "-ph" and "-p" would be recognised as the "-p" prefix.

however, we recently standardised the flags in an effort to make it consistent in all PRs. this resulted in the creation of the "-p" flag, which is a prefix of the existing "-ph" flag, causing the above issue.

lets require a whitespace after the flag as well when tokenizing arguments.