### PR TITLE
Allow reset of all optional fields

### DIFF
--- a/src/main/java/seedu/address/logic/commands/buyer/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/buyer/EditBuyerCommand.java
@@ -106,6 +106,9 @@ public class EditBuyerCommand extends Command {
         PriceRange updatedPriceRange = editBuyerDescriptor
                 .getPriceRange()
                 .orElse(buyerToEdit.getPriceRange().orElse(null));
+        if (updatedPriceRange != null && updatedPriceRange.getIsReset()) {
+            updatedPriceRange = null;
+        }
         Characteristics updatedCharacteristics = editBuyerDescriptor
                 .getDesiredCharacteristics()
                 .orElse(buyerToEdit.getDesiredCharacteristics().orElse(null));

--- a/src/main/java/seedu/address/logic/commands/buyer/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/buyer/EditBuyerCommand.java
@@ -109,6 +109,9 @@ public class EditBuyerCommand extends Command {
         Characteristics updatedCharacteristics = editBuyerDescriptor
                 .getDesiredCharacteristics()
                 .orElse(buyerToEdit.getDesiredCharacteristics().orElse(null));
+        if (updatedCharacteristics != null && updatedCharacteristics.isReset()) {
+            updatedCharacteristics = null;
+        }
         Priority updatedPriority = editBuyerDescriptor.getPriority().orElse(buyerToEdit.getPriority());
 
         LocalDateTime entryTime = buyerToEdit.getEntryTime();

--- a/src/main/java/seedu/address/logic/commands/buyer/EditBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/buyer/EditBuyerCommand.java
@@ -106,7 +106,7 @@ public class EditBuyerCommand extends Command {
         PriceRange updatedPriceRange = editBuyerDescriptor
                 .getPriceRange()
                 .orElse(buyerToEdit.getPriceRange().orElse(null));
-        if (updatedPriceRange != null && updatedPriceRange.getIsReset()) {
+        if (updatedPriceRange != null && updatedPriceRange.isReset()) {
             updatedPriceRange = null;
         }
         Characteristics updatedCharacteristics = editBuyerDescriptor

--- a/src/main/java/seedu/address/logic/commands/property/EditPropertyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/property/EditPropertyCommand.java
@@ -112,6 +112,9 @@ public class EditPropertyCommand extends Command {
         Characteristics updatedCharacteristics = descriptor
                 .getCharacteristics()
                 .orElse(propertyToEdit.getCharacteristics().orElse(null));
+        if (updatedCharacteristics != null && updatedCharacteristics.isReset()) {
+            updatedCharacteristics = null;
+        }
 
         // Allows for the changing of owner name and owner phone individually
         Name updatedOwnerName = descriptor.getOwnerName().orElse(propertyToEdit.getOwner().getName());

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -142,13 +142,11 @@ public class ParserUtil {
     public static PriceRange parsePriceRange(String range) throws ParseException {
         requireNonNull(range);
         String trimmedRange = range.trim();
-        /*TODO: Currently the price range accepted has to be in the exact format of LOW - HIGH
-        with no allowance for extra white spaces within e.g 200 -     500.
-        Accepted white spaces are only around e.g "    200 - 500     ".
-        Something to consider for further enhancement if we want to make it
-        more flexible, but not a priority!*/
         if (!PriceRange.isValidPriceRange(trimmedRange)) {
             throw new ParseException(PriceRange.MESSAGE_CONSTRAINTS);
+        }
+        if (trimmedRange.isEmpty()) {
+            return PriceRange.RESET_PRICE_RANGE;
         }
         return new PriceRange(trimmedRange);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -162,25 +162,10 @@ public class ParserUtil {
         if (!Characteristics.isValidCharacteristics(trimmedCharacteristics)) {
             throw new ParseException(Characteristics.MESSAGE_CONSTRAINTS);
         }
-        return new Characteristics(trimmedCharacteristics);
-    }
-
-    /**
-     * Parses {@code String properties} into a {@code List<Integer>}.
-     */
-    // TODO: Actually parse properties here?
-    public static Properties parseProperties(String properties) throws ParseException {
-        if (properties.isEmpty()) {
-            return new Properties("");
+        if (trimmedCharacteristics.isEmpty()) {
+            return Characteristics.RESET_CHARACTERISTICS;
         }
-        String trimmedProperties = properties.trim();
-        List<Integer> propertyArray = Arrays.stream(trimmedProperties.split(";"))
-                .map(item -> Integer.parseInt(item.trim()))
-                .collect(Collectors.toList());
-
-        // TODO: should add a check that all values that are ; separated are integers
-
-        return new Properties("");
+        return new Characteristics(trimmedCharacteristics);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,10 +3,6 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -21,7 +17,6 @@ import seedu.address.model.pricerange.PriceRange;
 import seedu.address.model.property.Description;
 import seedu.address.model.property.Owner;
 import seedu.address.model.property.Price;
-import seedu.address.model.property.Properties;
 import seedu.address.model.property.PropertyName;
 
 

--- a/src/main/java/seedu/address/logic/parser/buyer/AddBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/buyer/AddBuyerCommandParser.java
@@ -58,6 +58,7 @@ public class AddBuyerCommandParser extends Parser<AddBuyerCommand> {
         PriceRange priceRange = null;
         if (argMultimap.getValue(PREFIX_PRICE_RANGE).isPresent()) {
             priceRange = ParserUtil.parsePriceRange(argMultimap.getValue(PREFIX_PRICE_RANGE).get());
+            priceRange = priceRange.getIsReset() ? null : priceRange;
         }
         
         Characteristics characteristics = null;

--- a/src/main/java/seedu/address/logic/parser/buyer/AddBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/buyer/AddBuyerCommandParser.java
@@ -60,7 +60,7 @@ public class AddBuyerCommandParser extends Parser<AddBuyerCommand> {
             priceRange = ParserUtil.parsePriceRange(argMultimap.getValue(PREFIX_PRICE_RANGE).get());
             priceRange = priceRange.getIsReset() ? null : priceRange;
         }
-        
+
         Characteristics characteristics = null;
         if (argMultimap.getValue(PREFIX_CHARACTERISTICS).isPresent()) {
             characteristics = ParserUtil.parseCharacteristics(argMultimap.getValue(PREFIX_CHARACTERISTICS).get());

--- a/src/main/java/seedu/address/logic/parser/buyer/AddBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/buyer/AddBuyerCommandParser.java
@@ -59,11 +59,11 @@ public class AddBuyerCommandParser extends Parser<AddBuyerCommand> {
         if (argMultimap.getValue(PREFIX_PRICE_RANGE).isPresent()) {
             priceRange = ParserUtil.parsePriceRange(argMultimap.getValue(PREFIX_PRICE_RANGE).get());
         }
-
-        // TODO: Consider allowing multiple -c instead of separated by ; in one -c
+        
         Characteristics characteristics = null;
         if (argMultimap.getValue(PREFIX_CHARACTERISTICS).isPresent()) {
             characteristics = ParserUtil.parseCharacteristics(argMultimap.getValue(PREFIX_CHARACTERISTICS).get());
+            characteristics = characteristics.isReset() ? null : characteristics;
         }
 
         Priority priority = new Priority("normal");

--- a/src/main/java/seedu/address/logic/parser/buyer/AddBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/buyer/AddBuyerCommandParser.java
@@ -58,7 +58,7 @@ public class AddBuyerCommandParser extends Parser<AddBuyerCommand> {
         PriceRange priceRange = null;
         if (argMultimap.getValue(PREFIX_PRICE_RANGE).isPresent()) {
             priceRange = ParserUtil.parsePriceRange(argMultimap.getValue(PREFIX_PRICE_RANGE).get());
-            priceRange = priceRange.getIsReset() ? null : priceRange;
+            priceRange = priceRange.isReset() ? null : priceRange;
         }
 
         Characteristics characteristics = null;

--- a/src/main/java/seedu/address/logic/parser/buyer/EditBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/buyer/EditBuyerCommandParser.java
@@ -61,7 +61,6 @@ public class EditBuyerCommandParser extends Parser<EditBuyerCommand> {
         if (argMultimap.getValue(PREFIX_CHARACTERISTICS).isPresent()) {
             editBuyerDescriptor.setDesiredCharacteristics(ParserUtil
                     .parseCharacteristics(argMultimap.getValue(PREFIX_CHARACTERISTICS).get()));
-
         }
         if (argMultimap.getValue(PREFIX_PRIORITY).isPresent()) {
             editBuyerDescriptor.setPriority(ParserUtil

--- a/src/main/java/seedu/address/logic/parser/property/AddPropertyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/property/AddPropertyCommandParser.java
@@ -63,6 +63,7 @@ public class AddPropertyCommandParser extends Parser<AddPropertyCommand> {
         Characteristics characteristics = null;
         if (argMultimap.getValue(PREFIX_CHARACTERISTICS).isPresent()) {
             characteristics = ParserUtil.parseCharacteristics(argMultimap.getValue(PREFIX_CHARACTERISTICS).get());
+            characteristics = characteristics.isReset() ? null : characteristics;
         }
 
         Property property = new Property(propertyName, price, address, description,

--- a/src/main/java/seedu/address/model/characteristics/Characteristics.java
+++ b/src/main/java/seedu/address/model/characteristics/Characteristics.java
@@ -44,6 +44,7 @@ public class Characteristics {
      * Any string input, including an empty one, is a valid characteristic.
      */
     public static boolean isValidCharacteristics(String test) {
+        requireNonNull(test);
         return true;
     }
 

--- a/src/main/java/seedu/address/model/characteristics/Characteristics.java
+++ b/src/main/java/seedu/address/model/characteristics/Characteristics.java
@@ -13,11 +13,7 @@ public class Characteristics {
     public static final String MESSAGE_CONSTRAINTS = "If -c flag is used, "
             + "characteristics entry cannot be left blank.";
 
-    /*
-     * The first character of the characteristics must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    private static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final Characteristics RESET_CHARACTERISTICS = new Characteristics("RESET");
 
     private static final String CHARACTERISTIC_DELIMITER = ";";
 
@@ -45,10 +41,10 @@ public class Characteristics {
     }
 
     /**
-     * Returns true if a given user-input string is valid to be used in desired characteristics.
+     * Any string input, including an empty one, is a valid characteristic.
      */
     public static boolean isValidCharacteristics(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return true;
     }
 
     /**
@@ -104,4 +100,7 @@ public class Characteristics {
         return characteristicsArray.hashCode();
     }
 
+    public boolean isReset() {
+        return characteristicsArray[0].equals("RESET");
+    }
 }

--- a/src/main/java/seedu/address/model/pricerange/PriceRange.java
+++ b/src/main/java/seedu/address/model/pricerange/PriceRange.java
@@ -59,12 +59,14 @@ public class PriceRange {
      * Accepts an empty string.
      */
     public static boolean isValidPriceRange(String test) {
-        if (test.isEmpty()) {
+        requireNonNull(test);
+
+        if (test.trim().isEmpty()) {
             return true;
         }
 
         boolean isValid = test.matches(VALIDATION_REGEX);
-        
+
         // to prevent out of bounds error below
         if (!isValid) {
             return false;

--- a/src/main/java/seedu/address/model/pricerange/PriceRange.java
+++ b/src/main/java/seedu/address/model/pricerange/PriceRange.java
@@ -23,8 +23,11 @@ public class PriceRange {
      */
     public static final String VALIDATION_REGEX = "[0-9]*\\.?[0-9]+\\s*-\\s*[0-9]*\\.?[0-9]+";
 
+    public static final PriceRange RESET_PRICE_RANGE = new PriceRange();
+
     public final Price low;
     public final Price high;
+    public final boolean isReset;
 
     /**
      * Constructs a {@code PriceRange}.
@@ -37,17 +40,31 @@ public class PriceRange {
         String[] rangeValues = priceRange.split("-");
         this.low = new Price(rangeValues[0].trim());
         this.high = new Price(rangeValues[1].trim());
+        this.isReset = false;
+    }
+
+    /**
+     * Constructs a {@code PriceRange} that is going to be reset.
+     */
+    public PriceRange() {
+        this.low = null;
+        this.high = null;
+        this.isReset = true;
     }
 
     /**
      * Returns true if a given string is a valid price range in format.
      * Left value of the price range must be smaller than the right value of the price range.
      * Both values must be non-negative and within the maximum range of a Double.
+     * Accepts an empty string.
      */
     public static boolean isValidPriceRange(String test) {
+        if (test.isEmpty()) {
+            return true;
+        }
 
         boolean isValid = test.matches(VALIDATION_REGEX);
-
+        
         // to prevent out of bounds error below
         if (!isValid) {
             return false;
@@ -114,5 +131,9 @@ public class PriceRange {
         return other == this // short circuit if same object
                 || (other instanceof PriceRange // instanceof handles nulls
                 && this.toString().equals(((PriceRange) other).toString())); // state check
+    }
+
+    public boolean getIsReset() {
+        return isReset;
     }
 }

--- a/src/main/java/seedu/address/model/pricerange/PriceRange.java
+++ b/src/main/java/seedu/address/model/pricerange/PriceRange.java
@@ -46,7 +46,7 @@ public class PriceRange {
     /**
      * Constructs a {@code PriceRange} that is going to be reset.
      */
-    public PriceRange() {
+    private PriceRange() {
         this.low = null;
         this.high = null;
         this.isReset = true;

--- a/src/main/java/seedu/address/model/pricerange/PriceRange.java
+++ b/src/main/java/seedu/address/model/pricerange/PriceRange.java
@@ -135,7 +135,7 @@ public class PriceRange {
                 && this.toString().equals(((PriceRange) other).toString())); // state check
     }
 
-    public boolean getIsReset() {
+    public boolean isReset() {
         return isReset;
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -21,8 +21,6 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_PRICE_RANGE = "200";
-    private static final String INVALID_DESIRED_CHARACTERISTICS = "";
-    private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -171,11 +169,6 @@ public class ParserUtilTest {
     @Test
     public void parseCharacteristics_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseCharacteristics(null));
-    }
-
-    @Test
-    public void parseCharacteristics_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parsePriceRange(INVALID_DESIRED_CHARACTERISTICS));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/buyer/AddBuyerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/buyer/AddBuyerCommandParserTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.commands.BuyerCommandTestUtil.DESIRED_CHARACTE
 import static seedu.address.logic.commands.BuyerCommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.BuyerCommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.BuyerCommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.address.logic.commands.BuyerCommandTestUtil.INVALID_DESIRED_CHARACTERISTICS_DESC;
 import static seedu.address.logic.commands.BuyerCommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.BuyerCommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.BuyerCommandTestUtil.INVALID_PHONE_DESC;
@@ -43,7 +42,6 @@ import seedu.address.model.buyer.Email;
 import seedu.address.model.buyer.Name;
 import seedu.address.model.buyer.Phone;
 import seedu.address.model.buyer.Priority;
-import seedu.address.model.characteristics.Characteristics;
 import seedu.address.model.pricerange.PriceRange;
 import seedu.address.testutil.BuyerBuilder;
 
@@ -157,11 +155,6 @@ public class AddBuyerCommandParserTest {
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + INVALID_PRICE_RANGE_DESC + DESIRED_CHARACTERISTICS_DESC_BOB
                 + TAG_DESC_PRIORITY_LOW, PriceRange.MESSAGE_CONSTRAINTS);
-
-        // invalid desired characteristics
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + PRICE_RANGE_DESC_BOB + INVALID_DESIRED_CHARACTERISTICS_DESC
-                + TAG_DESC_PRIORITY_LOW, Characteristics.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/buyer/EditBuyerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/buyer/EditBuyerCommandParserTest.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.commands.BuyerCommandTestUtil.DESIRED_CHARACTE
 import static seedu.address.logic.commands.BuyerCommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.BuyerCommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.BuyerCommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.address.logic.commands.BuyerCommandTestUtil.INVALID_DESIRED_CHARACTERISTICS_DESC;
 import static seedu.address.logic.commands.BuyerCommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.BuyerCommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.BuyerCommandTestUtil.INVALID_PHONE_DESC;
@@ -48,7 +47,6 @@ import seedu.address.model.buyer.Email;
 import seedu.address.model.buyer.Name;
 import seedu.address.model.buyer.Phone;
 import seedu.address.model.buyer.Priority;
-import seedu.address.model.characteristics.Characteristics;
 import seedu.address.model.pricerange.PriceRange;
 import seedu.address.testutil.EditBuyerDescriptorBuilder;
 
@@ -95,8 +93,6 @@ public class EditBuyerCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
         assertParseFailure(parser, "1" + INVALID_PRICE_RANGE_DESC, PriceRange.MESSAGE_CONSTRAINTS); // invalid address
-        assertParseFailure(parser, "1" + INVALID_DESIRED_CHARACTERISTICS_DESC,
-                Characteristics.MESSAGE_CONSTRAINTS); // invalid address
         assertParseFailure(parser, "1" + INVALID_PRIORITY_DESC, Priority.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid phone followed by valid email

--- a/src/test/java/seedu/address/logic/parser/property/AddPropertyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/property/AddPropertyCommandParserTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.commands.PropertyCommandTestUtil.CHARACTERISTI
 import static seedu.address.logic.commands.PropertyCommandTestUtil.DESCRIPTION_DESC_HOME;
 import static seedu.address.logic.commands.PropertyCommandTestUtil.DESCRIPTION_DESC_PROPERTY1;
 import static seedu.address.logic.commands.PropertyCommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.address.logic.commands.PropertyCommandTestUtil.INVALID_CHARACTERISTICS_DESC;
 import static seedu.address.logic.commands.PropertyCommandTestUtil.INVALID_DESCRIPTION_DESC;
 import static seedu.address.logic.commands.PropertyCommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.PropertyCommandTestUtil.INVALID_OWNER_NAME_DESC;
@@ -33,7 +32,6 @@ import seedu.address.logic.commands.property.AddPropertyCommand;
 import seedu.address.model.address.Address;
 import seedu.address.model.buyer.Name;
 import seedu.address.model.buyer.Phone;
-import seedu.address.model.characteristics.Characteristics;
 import seedu.address.model.property.Description;
 import seedu.address.model.property.Price;
 import seedu.address.model.property.Property;
@@ -146,11 +144,6 @@ public class AddPropertyCommandParserTest {
         assertParseFailure(parser, NAME_DESC_HOME + PRICE_DESC_HOME + ADDRESS_DESC_HOME
                 + INVALID_DESCRIPTION_DESC + CHARACTERISTICS_DESC_HOME + OWNER_NAME_DESC_HOME
                 + OWNER_PHONE_DESC_HOME, Description.MESSAGE_CONSTRAINTS);
-
-        // invalid characteristics
-        assertParseFailure(parser, NAME_DESC_HOME + PRICE_DESC_HOME + ADDRESS_DESC_HOME
-                + DESCRIPTION_DESC_HOME + INVALID_CHARACTERISTICS_DESC + OWNER_NAME_DESC_HOME
-                + OWNER_PHONE_DESC_HOME, Characteristics.MESSAGE_CONSTRAINTS);
 
         // invalid owner name
         assertParseFailure(parser, NAME_DESC_HOME + PRICE_DESC_HOME + ADDRESS_DESC_HOME

--- a/src/test/java/seedu/address/logic/parser/property/EditPropertyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/property/EditPropertyCommandParserTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.commands.PropertyCommandTestUtil.CHARACTERISTI
 import static seedu.address.logic.commands.PropertyCommandTestUtil.DESCRIPTION_DESC_HOME;
 import static seedu.address.logic.commands.PropertyCommandTestUtil.DESCRIPTION_DESC_PROPERTY1;
 import static seedu.address.logic.commands.PropertyCommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.address.logic.commands.PropertyCommandTestUtil.INVALID_CHARACTERISTICS_DESC;
 import static seedu.address.logic.commands.PropertyCommandTestUtil.INVALID_DESCRIPTION_DESC;
 import static seedu.address.logic.commands.PropertyCommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.PropertyCommandTestUtil.INVALID_OWNER_NAME_DESC;
@@ -50,7 +49,6 @@ import seedu.address.logic.commands.property.EditPropertyCommand.EditPropertyDes
 import seedu.address.model.address.Address;
 import seedu.address.model.buyer.Name;
 import seedu.address.model.buyer.Phone;
-import seedu.address.model.characteristics.Characteristics;
 import seedu.address.model.property.Description;
 import seedu.address.model.property.Price;
 import seedu.address.model.property.PropertyName;
@@ -104,9 +102,6 @@ public class EditPropertyCommandParserTest {
 
         // invalid description
         assertParseFailure(parser, "1" + INVALID_DESCRIPTION_DESC, Description.MESSAGE_CONSTRAINTS);
-
-        // invalid characteristics
-        assertParseFailure(parser, "1" + INVALID_CHARACTERISTICS_DESC, Characteristics.MESSAGE_CONSTRAINTS);
 
         // invalid owner name
         assertParseFailure(parser, "1" + INVALID_OWNER_NAME_DESC, Name.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/model/characteristics/CharacteristicsTest.java
+++ b/src/test/java/seedu/address/model/characteristics/CharacteristicsTest.java
@@ -1,6 +1,5 @@
 package seedu.address.model.characteristics;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -16,23 +15,17 @@ public class CharacteristicsTest {
     }
 
     @Test
-    public void constructor_invalidDesiredCharacteristics_throwsIllegalArgumentException() {
-        String invalidDesiredCharacteristics = "";
-        assertThrows(IllegalArgumentException.class, () -> new Characteristics(invalidDesiredCharacteristics));
-    }
-
-    @Test
     public void isValidDesiredCharacteristics() {
         // null name
         assertThrows(NullPointerException.class, () -> Characteristics.isValidCharacteristics(null));
 
-        // invalid desired characteristics
-        assertFalse(Characteristics.isValidCharacteristics("")); // empty string
-        assertFalse(Characteristics.isValidCharacteristics(" ")); // spaces only
+        // no invalid desired characteristics
 
         // valid desired characteristics
         assertTrue(Characteristics.isValidCharacteristics("Bright"));
         assertTrue(Characteristics.isValidCharacteristics("Multiple words"));
         assertTrue(Characteristics.isValidCharacteristics("Words; Separated; "));
+        assertTrue(Characteristics.isValidCharacteristics("")); // empty string
+        assertTrue(Characteristics.isValidCharacteristics(" ")); // spaces only
     }
 }

--- a/src/test/java/seedu/address/model/pricerange/PriceRangeTest.java
+++ b/src/test/java/seedu/address/model/pricerange/PriceRangeTest.java
@@ -30,16 +30,17 @@ public class PriceRangeTest {
         assertThrows(NullPointerException.class, () -> PriceRange.isValidPriceRange(null));
 
         // invalid price range
-        assertFalse(PriceRange.isValidPriceRange("")); // empty string
-        assertFalse(PriceRange.isValidPriceRange(" ")); // spaces only
         assertFalse(PriceRange.isValidPriceRange("200")); // only one value
         assertFalse(PriceRange.isValidPriceRange("500-200")); // low before high
         assertFalse(PriceRange.isValidPriceRange("200;300")); // wrong separator
 
         // valid price range
+        assertTrue(PriceRange.isValidPriceRange("")); // empty string
+        assertTrue(PriceRange.isValidPriceRange(" ")); // spaces only
         assertTrue(PriceRange.isValidPriceRange("200 - 500"));
         assertTrue(PriceRange.isValidPriceRange("200 - 200")); // upper = lower
         assertTrue(PriceRange.isValidPriceRange("200-500")); // no spacing
+        assertTrue(PriceRange.isValidPriceRange("200-  500")); // multiple spaces
     }
 
     @Test


### PR DESCRIPTION
Fixes #189 

-r -c for addbuyer and editbuyer now accept empty/whitespace inputs and will reset the respective fields to "not specified"
and the same for -c for addprop and editprop 

- The implementation of editbuyer and editprop uses null for fields that are not edited by the user; so I can't pass in null to those fields to reset them as it will be mistaken as unedited and the original field values are retrieved instead, so I created reset singletons for those classes